### PR TITLE
Update Hose.cs

### DIFF
--- a/RoundsMod/Cards/Hose.cs
+++ b/RoundsMod/Cards/Hose.cs
@@ -15,10 +15,10 @@ namespace CommitmentCards.Cards
         public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
         {
             cardInfo.allowMultiple = false;
-            gun.attackSpeed *= 0.5f;
-            gun.damage *= .05f;
+            gun.attackSpeed = 0.5f;
+            gun.damage = .05f;
             gun.reloadTime = .01f;
-            gun.projectileSpeed *= .66f;
+            gun.projectileSpeed = .66f;
             UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
             //Edits values on card itself, which are then applied to the player in `ApplyCardStats`
         }


### PR DESCRIPTION
`SetupCard` is run whenever a card is visualized (hovered in the card bar/displayed for picking), and twice when it's built.

Avoid usage of `*=`, `-=`, `+=, etc. in it as this means that `gun.projectileSpeed *= .66f;` is actually doing `gun.projectileSpeed = Mathf.pow(.66f, timesCardHasBeenDisplayed);` instead of `gun.projectile = 0.66f;` which causes its values to greatly differ from the intended ones.

You want to use `gun.projectileSpeed *= .66f;` instead of `gun.projectile = 0.66f;` in `OnAddCard`, because that is run directly on the player when they take the card, rather than on the values of the card.