### PR TITLE
Addressing Lag and Persistence Issues

### DIFF
--- a/RoundsMod/Cards/Copy.cs
+++ b/RoundsMod/Cards/Copy.cs
@@ -14,26 +14,26 @@ namespace CommitmentCards.Cards
     {
         public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
             //Edits values on card itself, which are then applied to the player in `ApplyCardStats`
         }
         public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} OnAddCard called.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} OnAddCard called.");
             var card = HandManipulator.instance.DuplicateRandomCard(player, 1);
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} OnAddCard has completed DuplicateRandomCard with card  {card}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} OnAddCard has completed DuplicateRandomCard with card  {card}.");
             CommitmentCards.instance.ExecuteAfterSeconds(0.1f,  () => {
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Removing self.");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Removing self.");
                 HandManipulator.instance.RemoveCardType(player, ModdingUtils.Utils.Cards.instance.GetCardWithName(GetTitle()));
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Self removed.");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Self removed.");
 
             });
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
             //Edits values on player when card is selected
         }
         public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
 
             //Run when the card is removed from the player
         }

--- a/RoundsMod/Cards/Distill.cs
+++ b/RoundsMod/Cards/Distill.cs
@@ -14,7 +14,7 @@ namespace CommitmentCards.Cards
     {
         public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
             //Edits values on card itself, which are then applied to the player in `ApplyCardStats`
         }
         public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
@@ -25,16 +25,16 @@ namespace CommitmentCards.Cards
                 HandManipulator.instance.DuplicateRandomCard(player, 3);
             });
             CommitmentCards.instance.ExecuteAfterSeconds(0.2f, () => {
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Removing self.");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Removing self.");
                 HandManipulator.instance.RemoveCardType(player, ModdingUtils.Utils.Cards.instance.GetCardWithName(GetTitle()));
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Self removed.");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Self removed.");
             });
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
             //Edits values on player when card is selected
         }
         public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
 
             //Run when the card is removed from the player
         }

--- a/RoundsMod/Cards/Hose.cs
+++ b/RoundsMod/Cards/Hose.cs
@@ -19,20 +19,20 @@ namespace CommitmentCards.Cards
             gun.damage *= .05f;
             gun.reloadTime = .01f;
             gun.projectileSpeed *= .66f;
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
             //Edits values on card itself, which are then applied to the player in `ApplyCardStats`
         }
         public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
         {
             var constantFire = player.gameObject.AddComponent<ConstantFire>();
             constantFire.gun = gun;
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
             //Edits values on player when card is selected
         }
         public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
         {
             Destroy(player.gameObject.GetComponent<ConstantFire>());
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
             //Run when the card is removed from the player
         }
 

--- a/RoundsMod/Cards/Refine.cs
+++ b/RoundsMod/Cards/Refine.cs
@@ -14,7 +14,7 @@ namespace CommitmentCards.Cards
     {
         public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
             //Edits values on card itself, which are then applied to the player in `ApplyCardStats`
         }
         public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
@@ -25,17 +25,17 @@ namespace CommitmentCards.Cards
                 HandManipulator.instance.DuplicateRandomCard(player, 2);
             });
             CommitmentCards.instance.ExecuteAfterSeconds(0.2f, () => {
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Removing self.");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Removing self.");
                 HandManipulator.instance.RemoveCardType(player, ModdingUtils.Utils.Cards.instance.GetCardWithName(GetTitle()));
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Self removed.");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} Self removed.");
 
             });
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
             //Edits values on player when card is selected
         }
         public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
 
             //Run when the card is removed from the player
         }

--- a/RoundsMod/Cards/Template.cs
+++ b/RoundsMod/Cards/Template.cs
@@ -13,17 +13,17 @@ namespace CommitmentCards.Cards
     {
         public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been setup.");
             //Edits values on card itself, which are then applied to the player in `ApplyCardStats`
         }
         public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been added to player {player.playerID}.");
             //Edits values on player when card is selected
         }
         public override void OnRemoveCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][Card] {GetTitle()} has been removed from player {player.playerID}.");
             //Run when the card is removed from the player
         }
 

--- a/RoundsMod/CommitmentCards.cs
+++ b/RoundsMod/CommitmentCards.cs
@@ -24,6 +24,11 @@ namespace CommitmentCards
         public const string ModInitials = "CC";
         public static CommitmentCards instance { get; private set; }
 
+#if DEBUG
+        public static readonly bool DEBUG = true;
+#else
+        public static readonly bool DEBUG = false;
+#endif
 
         void Awake()
         {
@@ -40,6 +45,14 @@ namespace CommitmentCards
             CustomCard.BuildCard<Hose>();
 
             gameObject.GetOrAddComponent<HandManipulator>();
+        }
+
+        internal static void Log(string message)
+        {
+            if (DEBUG)
+            {
+                CommitmentCards.Log(message);
+            }
         }
 
     }

--- a/RoundsMod/Patches/PlayerPatchFullReset.cs
+++ b/RoundsMod/Patches/PlayerPatchFullReset.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using HarmonyLib;
+using CommitmentCards.Scripts;
+using UnityEngine;
+
+namespace CommitmentCards.Patches
+{
+    // patch to reset card effects
+    [Serializable]
+    [HarmonyPatch(typeof(Player), "FullReset")]
+    class PlayerPatchFullReset
+    {
+        private static void Prefix(Player __instance)
+        {
+            if (__instance.GetComponent<ConstantFire>() != null) { UnityEngine.GameObject.Destroy(__instance.GetComponent<ConstantFire>()); }
+        }
+    }
+}

--- a/RoundsMod/Scripts/ConstantFire.cs
+++ b/RoundsMod/Scripts/ConstantFire.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using ModdingUtils.Utils;
 
 namespace CommitmentCards.Scripts
 {
@@ -10,10 +11,11 @@ namespace CommitmentCards.Scripts
         public Gun gun;
         void Update()
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] ConstantFire updating");
+            if (this.GetComponent<Player>()!=null && !PlayerStatus.PlayerAliveAndSimulated(this.GetComponent<Player>())) { return; }
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] ConstantFire updating");
             if (gun.IsReady())
             {
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] ConstantFire gun ready, attacking");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] ConstantFire gun ready, attacking");
                 gun.Attack(1);
             }
         }

--- a/RoundsMod/Scripts/HandManipulator.cs
+++ b/RoundsMod/Scripts/HandManipulator.cs
@@ -13,17 +13,17 @@ namespace CommitmentCards.Scripts
         private void Start()
         {
             instance = this;
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator has been started");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator has been started");
         }
         public CardInfo DuplicateRandomCard(Player player, int amount)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator DuplicateRandomCard called for player {player} and amount {amount}");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator DuplicateRandomCard called for player {player} and amount {amount}");
             var randomCard = SelectRandomCardWithStats(player);
             if (randomCard == null)
             {
                 return null;
             }
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator DuplicateRandomCard selected card: {randomCard} {randomCard.cardName}");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator DuplicateRandomCard selected card: {randomCard} {randomCard.cardName}");
             for (int i=0; i < amount; i++){
                 ModdingUtils.Utils.Cards.instance.AddCardToPlayer(player, randomCard, false, "", 0, 0, true);
             }
@@ -45,31 +45,31 @@ namespace CommitmentCards.Scripts
         }
         public Player RemoveCardType(Player player, CardInfo cardInfo)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator RemoveCardType called on card {cardInfo}");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator RemoveCardType called on card {cardInfo}");
             ModdingUtils.Utils.Cards.instance.RemoveCardFromPlayer(player, cardInfo, ModdingUtils.Utils.Cards.SelectionType.Random);
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator RemoveCardType finished for card {cardInfo}");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator RemoveCardType finished for card {cardInfo}");
             return player;
         }
         private CardInfo SelectRandomCardWithStats(Player player)
         {
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator SelectRandomCardWithStats called with player {player}");
-            player.data.currentCards.ForEach(card => UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator Currently held card regardles of stats: {card}"));
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator SelectRandomCardWithStats called with player {player}");
+            player.data.currentCards.ForEach(card => CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator Currently held card regardles of stats: {card}"));
             var cards = player.data.currentCards.Where(card => card.cardStats.Length > 0 && ModdingUtils.Utils.Cards.instance.PlayerIsAllowedCard(player, card)).ToList();
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator SelectRandomCardWithStats Currently held card with stats: {cards}");
-            cards.ForEach(card => UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator card: {card}"));
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator SelectRandomCardWithStats Currently held card with stats: {cards}");
+            cards.ForEach(card => CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator card: {card}"));
             
             if (cards == null)
             {
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator cards with stats was null ");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator cards with stats was null ");
                 return null;
             }
             if (cards.Count == 0)
             {
-                UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator cards with stats was empty ");
+                CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator cards with stats was empty ");
                 return null;
             }
             var randomCard = cards[UnityEngine.Random.Range(0, cards.Count)];
-            UnityEngine.Debug.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator Random card selected: {randomCard}");
+            CommitmentCards.Log($"[{CommitmentCards.ModInitials}][MonoBehaviour] HandManipulator Random card selected: {randomCard}");
             return randomCard;
         }
     }


### PR DESCRIPTION
Excessive debug logging can cause significant lag. I've added a `DEBUG` flag, which Visual Studio will automatically set to `true` or `false` when you switch your build type to `Debug` or `Release` respectively. When `DEBUG` is `true`, no output will be logged.

`ConstantFire` would cause players to continuously fire during the _pick_ phase, causing significant lag. I've added a check to the `Update` method so that if the player isn't both alive and simulated, then it won't cause the player to shoot.

Due to a quirk in how cards are applied and removed, `OnRemoveCard` isn't actually called at the end of the game when the host selects `Rematch`. As such, `ConstantFire` was not being removed after a rematch. The way to fix this is to add a pass-through prefix to `Player.FullReset`, which I've added in `CommitmentCards.Patches.PlayerPatchFullReset`.